### PR TITLE
Update Slscq::get_random_num in main.cpp

### DIFF
--- a/cpp_ver/main.cpp
+++ b/cpp_ver/main.cpp
@@ -52,7 +52,7 @@ public:
 
 int Slscq::get_random_num(unsigned long total)
 {
-    srand((unsigned int)clock());
+    srand((unsigned int)time(NULL));
     int num = rand() % (total);
     return num;
 }


### PR DESCRIPTION
`clock()` returns total running time instead of the unix system time, which makes the random seeds nearly always the same, therefore reduces randomness.
To solve this problem, use `time()` which returns the unix system time.